### PR TITLE
Added the option to open a CSV file with a custom encoding

### DIFF
--- a/bankcsvtoqif/banks/dkb_giro.py
+++ b/bankcsvtoqif/banks/dkb_giro.py
@@ -32,19 +32,15 @@ class DKBGiro(BankAccountConfig):
         self.delimiter = ';'
         self.quotechar = '"'
         self.dropped_lines = 7
-        #self.default_source_account = 'Assets:Current Assets:Checking Account'
-        self.default_source_account = 'Assets:Current Assets:Checking DKB (+VISA)'
+        self.default_source_account = 'Assets:Current Assets:Checking Account'
         self.default_target_account = 'Imbalance-EUR'
 
     def get_date(self, line):
         s = line[0].split('.')
         return datetime(int(s[2]), int(s[1]), int(s[0]))
 
-    #def get_description(self, line):
-    #    return line[4]
-
     def get_description(self, line):
-        description = line[3] + ' ' + line[4]
+        description = line[2] + ' ' + line[3] + ' ' + line[4]
         return ' '.join(description.split())
 
     def get_debit(self, line):

--- a/bankcsvtoqif/banks/dkb_giro.py
+++ b/bankcsvtoqif/banks/dkb_giro.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+
+# BankCSVtoQif - Smart conversion of csv files from a bank to qif
+# Copyright (C) 2015-2016  Nikolai Nowaczyk
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from bankcsvtoqif.banks import BankAccountConfig
+from datetime import datetime
+
+
+class DKBGiro(BankAccountConfig):
+    """ Deutsche Kreditbank Girokonto """
+
+    def __init__(self):
+        BankAccountConfig.__init__(self)
+
+        self.encoding = 'windows-1252'
+        self.delimiter = ';'
+        self.quotechar = '"'
+        self.dropped_lines = 7
+        #self.default_source_account = 'Assets:Current Assets:Checking Account'
+        self.default_source_account = 'Assets:Current Assets:Checking DKB (+VISA)'
+        self.default_target_account = 'Imbalance-EUR'
+
+    def get_date(self, line):
+        s = line[0].split('.')
+        return datetime(int(s[2]), int(s[1]), int(s[0]))
+
+    #def get_description(self, line):
+    #    return line[4]
+
+    def get_description(self, line):
+        description = line[3] + ' ' + line[4]
+        return ' '.join(description.split())
+
+    def get_debit(self, line):
+        val = self.get_amount(line[7])
+        return -val if val < 0 else 0
+
+    def get_credit(self, line):
+        val = self.get_amount(line[7])
+        return val if val >= 0 else 0

--- a/bankcsvtoqif/banks/dkb_visa.py
+++ b/bankcsvtoqif/banks/dkb_visa.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+
+# BankCSVtoQif - Smart conversion of csv files from a bank to qif
+# Copyright (C) 2015-2016  Nikolai Nowaczyk
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from bankcsvtoqif.banks import BankAccountConfig
+from datetime import datetime
+
+
+class DKBVisa(BankAccountConfig):
+    """ Deutsche Kreditbank Visacard """
+
+    def __init__(self):
+        BankAccountConfig.__init__(self)
+
+        self.encoding = 'windows-1252'
+        self.delimiter = ';'
+        self.quotechar = '"'
+        self.dropped_lines = 7
+        self.default_source_account = 'Assets:Current Assets:Checking Account'
+        self.default_target_account = 'Imbalance-EUR'
+
+    def get_date(self, line):
+        s = line[1].split('.')
+        return datetime(int(s[2]), int(s[1]), int(s[0]))
+
+    def get_description(self, line):
+        description = line[3]
+        return ' '.join(description.split())
+
+    def get_debit(self, line):
+        val = self.get_amount(line[4])
+        return -val if val < 0 else 0
+
+    def get_credit(self, line):
+        val = self.get_amount(line[4])
+        return val if val >= 0 else 0

--- a/bankcsvtoqif/io.py
+++ b/bankcsvtoqif/io.py
@@ -77,7 +77,10 @@ class DataManager(object):
             self.messenger.send_message(transaction)
 
     def csv_to_qif(self):
-        f = open(self.csv_filename)
+        try:
+            f = open(self.csv_filename, encoding=self.account_config.encoding)
+        except AttributeError:
+            f = open(self.csv_filename)
         self.read_csv(f)
         f.close()
         if self.replacements_file:

--- a/bankcsvtoqif/tests/banks/test_dkb_giro.py
+++ b/bankcsvtoqif/tests/banks/test_dkb_giro.py
@@ -29,7 +29,7 @@ class TestDKBGiro(unittest.TestCase):
 
     def setUp(self):
         self.csv = """21.06.2017;21.06.2017;"Kartenzahlung";\
-        "Geschäft";"Ticket";;;"-13,50";;;;""".encode(encoding='windows-1252')
+        "Geschäft";"Ticket";;;"-13,50";;;;"""
 
     def test_can_instantiate(self):
         account_config = DKBGiro()

--- a/bankcsvtoqif/tests/banks/test_dkb_giro.py
+++ b/bankcsvtoqif/tests/banks/test_dkb_giro.py
@@ -28,8 +28,7 @@ from bankcsvtoqif.banks.dkb_giro import DKBGiro
 class TestDKBGiro(unittest.TestCase):
 
     def setUp(self):
-        self.csv = """21.06.2017;21.06.2017;"Kartenzahlung";\
-        "Geschäft";"Ticket";;;"-13,50";;;;"""
+        self.csv = """21.06.2017;;Kartenzahlung;Geschäft;Ticket;;;-13,50;;;;"""
 
     def test_can_instantiate(self):
         account_config = DKBGiro()
@@ -40,8 +39,8 @@ class TestDKBGiro(unittest.TestCase):
         line = csvline_to_line(self.csv, account_config)
         date = datetime(2017, 6, 21)
         description = 'Kartenzahlung Geschäft Ticket'
-        debit = 0
-        credit = -13.5
+        debit = 13.5
+        credit = 0
         self.assertEqual(account_config.get_date(line), date)
         self.assertEqual(account_config.get_description(line), description)
         self.assertEqual(account_config.get_debit(line), debit)

--- a/bankcsvtoqif/tests/banks/test_dkb_giro.py
+++ b/bankcsvtoqif/tests/banks/test_dkb_giro.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+
+# BankCSVtoQif - Smart conversion of csv files from a bank to qif
+# Copyright (C) 2015-2016  Nikolai Nowaczyk
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import unittest
+from datetime import datetime
+from bankcsvtoqif.tests.banks import csvline_to_line
+
+from bankcsvtoqif.banks.dkb_giro import DKBGiro
+
+
+class TestDKBGiro(unittest.TestCase):
+
+    def setUp(self):
+        self.csv = """21.06.2017;21.06.2017;"Kartenzahlung";\
+        "Geschäft";"Ticket";;;"-13,50";;;;""".encode(encoding='windows-1252')
+
+    def test_can_instantiate(self):
+        account_config = DKBGiro()
+        self.assertEqual(type(account_config), DKBGiro)
+
+    def test_getters(self):
+        account_config = DKBGiro()
+        line = csvline_to_line(self.csv, account_config)
+        date = datetime(2017, 6, 21)
+        description = 'Kartenzahlung Geschäft Ticket'
+        debit = 0
+        credit = -13.5
+        self.assertEqual(account_config.get_date(line), date)
+        self.assertEqual(account_config.get_description(line), description)
+        self.assertEqual(account_config.get_debit(line), debit)
+        self.assertEqual(account_config.get_credit(line), credit)

--- a/bankcsvtoqif/tests/banks/test_dkb_visa.py
+++ b/bankcsvtoqif/tests/banks/test_dkb_visa.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+
+# BankCSVtoQif - Smart conversion of csv files from a bank to qif
+# Copyright (C) 2015-2016  Nikolai Nowaczyk
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import unittest
+from datetime import datetime
+from bankcsvtoqif.tests.banks import csvline_to_line
+
+from bankcsvtoqif.banks.dkb_visa import DKBVisa
+
+
+class TestDKBVisa(unittest.TestCase):
+
+    def setUp(self):
+        self.csv = """;;23.06.2017;;;Steuer;"-0,2";;""".encode(encoding='windows-1252')
+
+    def test_can_instantiate(self):
+        account_config = DKBVisa()
+        self.assertEqual(type(account_config), DKBVisa)
+
+    def test_getters(self):
+        account_config = DKBVisa()
+        line = csvline_to_line(self.csv, account_config)
+        date = datetime(2017, 6, 23)
+        description = 'Steuer'
+        debit = 0
+        credit = -0.2
+        self.assertEqual(account_config.get_date(line), date)
+        self.assertEqual(account_config.get_description(line), description)
+        self.assertEqual(account_config.get_debit(line), debit)
+        self.assertEqual(account_config.get_credit(line), credit)

--- a/bankcsvtoqif/tests/banks/test_dkb_visa.py
+++ b/bankcsvtoqif/tests/banks/test_dkb_visa.py
@@ -28,7 +28,7 @@ from bankcsvtoqif.banks.dkb_visa import DKBVisa
 class TestDKBVisa(unittest.TestCase):
 
     def setUp(self):
-        self.csv = """;;23.06.2017;;;Steuer;"-0,2";;""".encode(encoding='windows-1252')
+        self.csv = """;;23.06.2017;;;Steuer;"-0,2";;"""
 
     def test_can_instantiate(self):
         account_config = DKBVisa()

--- a/bankcsvtoqif/tests/banks/test_dkb_visa.py
+++ b/bankcsvtoqif/tests/banks/test_dkb_visa.py
@@ -28,7 +28,7 @@ from bankcsvtoqif.banks.dkb_visa import DKBVisa
 class TestDKBVisa(unittest.TestCase):
 
     def setUp(self):
-        self.csv = """;;23.06.2017;;;Steuer;"-0,2";;"""
+        self.csv = """;23.06.2017;;Steuer;"-0,2";;"""
 
     def test_can_instantiate(self):
         account_config = DKBVisa()
@@ -39,8 +39,8 @@ class TestDKBVisa(unittest.TestCase):
         line = csvline_to_line(self.csv, account_config)
         date = datetime(2017, 6, 23)
         description = 'Steuer'
-        debit = 0
-        credit = -0.2
+        debit = 0.2
+        credit = 0
         self.assertEqual(account_config.get_date(line), date)
         self.assertEqual(account_config.get_description(line), description)
         self.assertEqual(account_config.get_debit(line), debit)


### PR DESCRIPTION
When I tried to add a BankAccountConfig file for DKB (Deutsche Kreditbank), I found that their CSV-files are not in UTF8, but in 'windows-1252' encoding (makes a difference due to German umlauts). Hence I added the option to set a custom encoding in the respective BankAccountConfig file as "self.encoding = '...'".

I will add the DKB BankAccountConfig files in a separate commit.