### PR TITLE
Add Orient Corporation (Orico)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IntelliJ
+.idea/

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,27 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "f86c40cc864685579c14f4d91ee90a0c8dbd7bb5ee0dba882e8ffb9295c339bc"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "monthdelta": {
+            "hashes": [
+                "sha256:3e3453c332a6e309a58f4ad54bfe9b475e76685bc265a25b0ae6e16b86044292",
+                "sha256:81c09ec1d4d2861d7030c4a847db43550d1740e3d383707980854b9fcfd48c47"
+            ],
+            "index": "pypi",
+            "version": "==0.9.1"
+        }
+    },
+    "develop": {}
+}

--- a/bankcsvtoqif/banks/orico.py
+++ b/bankcsvtoqif/banks/orico.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+
+# BankCSVtoQif - Smart conversion of csv files from a bank to qif
+# Copyright (C) 2015-2016  Nikolai Nowaczyk
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from datetime import datetime
+import re
+
+from bankcsvtoqif.banks import BankAccountConfig
+
+
+class Orico(BankAccountConfig):
+    """ Orient Corporation (Orico) """
+
+    amount_sanitization_regex = re.compile(r"^\\")
+
+    def __init__(self):
+        BankAccountConfig.__init__(self)
+
+        self.delimiter = ','
+        self.quotechar = '"'
+        self.dropped_lines = 10
+        self.default_source_account = 'Assets:Current Assets:Checking Account'
+        self.default_target_account = 'Imbalance-JPY'
+        self.encoding = 'shift-jis'
+
+    def get_date(self, line):
+        return datetime.strptime(line[0], "%Y年%m月%d日")
+
+    def get_description(self, line):
+        return line[1]
+
+    def get_amount(self, amount):
+        amount = self.amount_sanitization_regex.sub("", amount)
+        amount = amount.replace(",", "")
+        return int(amount)
+
+    def get_debit(self, line):
+        amount = self.get_amount(line[8])
+        return -amount if amount <= 0 else 0
+
+    def get_credit(self, line):
+        amount = self.get_amount(line[8])
+        return amount if amount >= 0 else 0

--- a/bankcsvtoqif/banks/orico.py
+++ b/bankcsvtoqif/banks/orico.py
@@ -43,7 +43,7 @@ class Orico(BankAccountConfig):
         return datetime.strptime(line[0], "%Y年%m月%d日")
 
     def get_description(self, line):
-        return line[1]
+        return "{}（{}）".format(line[1], line[3])
 
     def get_amount(self, amount):
         amount = self.amount_sanitization_regex.sub("", amount)

--- a/bankcsvtoqif/tests/banks/test_orico.py
+++ b/bankcsvtoqif/tests/banks/test_orico.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+
+# BankCSVtoQif - Smart conversion of csv files from a bank to qif
+# Copyright (C) 2015-2016  Nikolai Nowaczyk
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import unittest
+from datetime import datetime
+
+from bankcsvtoqif.banks.orico import Orico
+from bankcsvtoqif.tests.banks import csvline_to_line
+
+
+class TestOrico(unittest.TestCase):
+
+    def setUp(self):
+        self.csv = r"""2021年3月1日,This is a debit テスト,null,家族,2021年3月,アド,,,"\-4,000",,,,-,-"""
+        self.csv2 = r'''2021年3月10日,This is a credit テスト,*,本人,2021年3月,アド,1,1,"\5,000",,,"\0","\5,000","\0"'''
+
+    def test_can_instantiate(self):
+        account_config = Orico()
+        self.assertEqual(type(account_config), Orico)
+
+    def test_debit(self):
+        account_config = Orico()
+        line = csvline_to_line(self.csv, account_config)
+        date = datetime(2021, 3, 1)
+        description = 'This is a debit テスト'
+        debit = 4000
+        credit = 0
+        self.assertEqual(account_config.get_date(line), date)
+        self.assertEqual(account_config.get_description(line), description)
+        self.assertEqual(account_config.get_debit(line), debit)
+        self.assertEqual(account_config.get_credit(line), credit)
+
+    def test_credit(self):
+        account_config = Orico()
+        line = csvline_to_line(self.csv2, account_config)
+        date = datetime(2021, 3, 10)
+        description = 'This is a credit テスト'
+        debit = 0
+        credit = 5000
+        self.assertEqual(account_config.get_date(line), date)
+        self.assertEqual(account_config.get_description(line), description)
+        self.assertEqual(account_config.get_debit(line), debit)
+        self.assertEqual(account_config.get_credit(line), credit)

--- a/bankcsvtoqif/tests/banks/test_orico.py
+++ b/bankcsvtoqif/tests/banks/test_orico.py
@@ -39,7 +39,7 @@ class TestOrico(unittest.TestCase):
         account_config = Orico()
         line = csvline_to_line(self.csv, account_config)
         date = datetime(2021, 3, 1)
-        description = 'This is a debit テスト'
+        description = 'This is a debit テスト（家族）'
         debit = 4000
         credit = 0
         self.assertEqual(account_config.get_date(line), date)
@@ -51,7 +51,7 @@ class TestOrico(unittest.TestCase):
         account_config = Orico()
         line = csvline_to_line(self.csv2, account_config)
         date = datetime(2021, 3, 10)
-        description = 'This is a credit テスト'
+        description = 'This is a credit テスト（本人）'
         debit = 0
         credit = 5000
         self.assertEqual(account_config.get_date(line), date)


### PR DESCRIPTION
Add support for Orico credit card CSV files.

Sample file: [orico.csv](https://github.com/niknow/BankCSVtoQif/files/6175833/orico.csv.txt)

Orico's files are in Japanese (it is a Japanese company) and are encoded in Shift-JIS.